### PR TITLE
Remove beta and limit from Live Stream operations

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5053,8 +5053,7 @@ paths:
                   String liveStreamId = "li400mYKSgQ6xs7taUeSaEKr"; // The unique ID for the live stream that you want to update information for such as player details, or whether you want the recording on or off.
                   LiveStreamUpdatePayload liveStreamUpdatePayload = new LiveStreamUpdatePayload(); // 
                   liveStreamUpdatePayload.setName("My Live Stream Video"); // The name you want to use for your live stream.
-                  liveStreamUpdatePayload.setPublic(); // BETA FEATURE Please limit all public &#x3D; false (&quot;private&quot;) livestreams to 3,000 users.
-              Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.
+                  liveStreamUpdatePayload.setPublic(); // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.
                   liveStreamUpdatePayload.setRecord(true); // Use this to indicate whether you want the recording on or off. On is true, off is false.
                   liveStreamUpdatePayload.setPlayerId("pl45KFKdlddgk654dspkze"); // The unique ID for the player associated with a live stream that you want to update.
 
@@ -11390,7 +11389,7 @@ components:
           example: true
         public:
           type: boolean
-          description: 'BETA FEATURE Please limit all public = false ("private") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
           example: true
         assets:
           $ref: '#/components/schemas/live-stream-assets'
@@ -11893,7 +11892,7 @@ components:
           default: false
         public:
           type: boolean
-          description: 'BETA FEATURE Please limit all public = false ("private") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
         playerId:
           type: string
           description: The unique identifier for the player.
@@ -11912,7 +11911,7 @@ components:
           example: My Live Stream Video
         public:
           type: boolean
-          description: 'BETA FEATURE Please limit all public = false ("private") livestreams to 3,000 users. Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
         record:
           type: boolean
           description: 'Use this to indicate whether you want the recording on or off. On is true, off is false.'

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -11389,7 +11389,7 @@ components:
           example: true
         public:
           type: boolean
-          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view. Learn more about the Private Video feature [here](https://docs.api.video/docs/private-videos).'
           example: true
         assets:
           $ref: '#/components/schemas/live-stream-assets'
@@ -11892,7 +11892,7 @@ components:
           default: false
         public:
           type: boolean
-          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view. Learn more about the Private Video feature [here](https://docs.api.video/docs/private-videos).'
         playerId:
           type: string
           description: The unique identifier for the player.
@@ -11911,7 +11911,7 @@ components:
           example: My Live Stream Video
         public:
           type: boolean
-          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.'
+          description: 'Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view. Learn more about the Private Video feature [here](https://docs.api.video/docs/private-videos).'
         record:
           type: boolean
           description: 'Use this to indicate whether you want the recording on or off. On is true, off is false.'


### PR DESCRIPTION
The changes are part of [this](https://app.asana.com/0/1204370684353095/1204582742867735/f) task.

**Summary**: removing the mentions of beta and limit from the field descriptions and code snippets on these API reference pages:

- Create live stream [API reference page](https://docs.api.video/reference/post_live-streams)
- Update live stream [API reference page](https://docs.api.video/reference/patch_live-streams-livestreamid)