### PR TITLE
Update live-stream.broadcast.ended description

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -10324,7 +10324,7 @@ paths:
         Webhooks can push notifications to your server, rather than polling api.video for changes. We currently offer four events: 
         * ```video.encoding.quality.completed``` Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ "type": "video.encoding.quality.completed", "emittedAt": "2021-01-29T16:46:25.217+01:00", "videoId": "viXXXXXXXX", "encoding": "hls", "quality": "720p"} ```. This request says that the 720p HLS encoding was completed.
         * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-        * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from false to true.
+        * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from true to false.
         * ```video.source.recorded```  This event occurs when a live stream is recorded and submitted for encoding.
       operationId: POST-webhooks
       requestBody:
@@ -12076,7 +12076,7 @@ components:
             A list of the webhooks that you are subscribing to. There are Currently four webhook options:
             * ```video.encoding.quality.completed```  Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ \"type\": \"video.encoding.quality.completed\", \"emittedAt\": \"2021-01-29T16:46:25.217+01:00\", \"videoId\": \"viXXXXXXXX\", \"encoding\": \"hls\", \"quality\": \"720p\"} ```. This request says that the 720p HLS encoding was completed.
             * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-            * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from false to true.
+            * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from true to false.
             * ```video.source.recorded```  Occurs when a live stream is recorded and submitted for encoding.
           example:
             - video.encoding.quality.completed

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -10324,7 +10324,7 @@ paths:
         Webhooks can push notifications to your server, rather than polling api.video for changes. We currently offer four events: 
         * ```video.encoding.quality.completed``` Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ "type": "video.encoding.quality.completed", "emittedAt": "2021-01-29T16:46:25.217+01:00", "videoId": "viXXXXXXXX", "encoding": "hls", "quality": "720p"} ```. This request says that the 720p HLS encoding was completed.
         * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-        * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from true to false.
+        * ```live-stream.broadcast.ended```  This event fires when a live stream has finished broadcasting.
         * ```video.source.recorded```  This event occurs when a live stream is recorded and submitted for encoding.
       operationId: POST-webhooks
       requestBody:
@@ -12076,7 +12076,7 @@ components:
             A list of the webhooks that you are subscribing to. There are Currently four webhook options:
             * ```video.encoding.quality.completed```  Occurs when a new video is uploaded into your account, it will be encoded into several different HLS and mp4 qualities. When each version is encoded, your webhook will get a notification.  It will look like ```{ \"type\": \"video.encoding.quality.completed\", \"emittedAt\": \"2021-01-29T16:46:25.217+01:00\", \"videoId\": \"viXXXXXXXX\", \"encoding\": \"hls\", \"quality\": \"720p\"} ```. This request says that the 720p HLS encoding was completed.
             * ```live-stream.broadcast.started```  When a live stream begins broadcasting, the broadcasting parameter changes from false to true, and this webhook fires.
-            * ```live-stream.broadcast.ended```  This event fires when the live stream has finished broadcasting, and the broadcasting parameter flips from true to false.
+            * ```live-stream.broadcast.ended```  This event fires when a live stream has finished broadcasting.
             * ```video.source.recorded```  Occurs when a live stream is recorded and submitted for encoding.
           example:
             - video.encoding.quality.completed


### PR DESCRIPTION
During review, we've found that the trigger conditions for `live-stream.broadcast.ended` were described incorrectly on the [Create webhooks](https://docs.api.video/reference/post-webhooks) page.

This PR is for [this](https://app.asana.com/0/1204370684353095/1204626782573063/f) Asana task.