### PR TITLE
Update retrieve a video summary

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -2073,7 +2073,7 @@ paths:
     get:
       tags:
         - Videos
-      summary: Retrieve a video
+      summary: Retrieve a video object
       description: Retrieve the video details by video id.
       x-client-description:
         default: 'This call provides the same information provided on video creation. For private videos, it will generate a unique token url. Use this to retrieve any details you need about a video, or set up a private viewing URL.'

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -165,8 +165,8 @@ paths:
     get:
       tags:
         - Videos
-      summary: List all videos
-      description: List all the videos that are associated with the currecnt workspace.
+      summary: List all video objects
+      description: List all the video objects that are associated with the current workspace.
       x-client-description:
         default: 'This method returns a list of your videos (with all their details). With no parameters added, the API returns the first page of all videos. You can filter videos using the parameters described below.'
       operationId: LIST-videos


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204370684353095/1204659210666148).

Updated the titles for:
* [Get video](https://docs.api.video/reference/get-video) from "Retrieve a video" to "Retrieve a video object"
* [List all videos](https://docs.api.video/reference/list-videos) from "List all videos" to "List all video objects"