### PR TITLE
Fix typo in video-watermark.height description

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -12124,11 +12124,11 @@ components:
           example: 10px
         width:
           type: string
-          description: 'Width of the watermark-image relative to the video if expressed in %. Otherwise a fixed width. NOTE: To keep intrinsic watermark-image width use initial'
+          description: 'Width of the watermark-image relative to the video if expressed in %. Otherwise a fixed width. NOTE: To keep intrinsic watermark-image width use `initial`.'
           example: initial
         height:
           type: string
-          description: 'Width of the watermark-image relative to the video if expressed in %. Otherwise a fixed height. NOTE: To keep intrinsic watermark-image height use initial'
+          description: 'Height of the watermark-image relative to the video if expressed in %. Otherwise a fixed height. NOTE: To keep intrinsic watermark-image height use `initial`.'
           example: initial
         opacity:
           type: string


### PR DESCRIPTION
The change is for [this Asana task](https://app.asana.com/0/1204370684353095/1204695391555728).

I've fixed the typo in the description for the `video-watermark.height` field on the Create a video object [API reference page](https://docs.api.video/reference/post-video).

I also added inline code formatting for the `initial` value for easier reading.