### PR TITLE
Remove nullable: false from restreams

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -12490,7 +12490,6 @@ components:
         restreams:
           description: Returns the list of RTMP restream destinations.
           type: array
-          nullable: false
           items:
             $ref: '#/components/schemas/restreams-response-object'
         createdAt:
@@ -12994,7 +12993,6 @@ components:
           description: Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
           maxItems: 5
           type: array
-          nullable: false
           items:
             $ref: '#/components/schemas/restreams-request-object'
       example:
@@ -13031,7 +13029,6 @@ components:
           description: Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations. This operation updates all restream destinations in the same request. If you do not want to modify an existing restream destination, you need to include it in your request, otherwise it is removed.
           maxItems: 5
           type: array
-          nullable: false
           items:
             $ref: '#/components/schemas/restreams-request-object'
     restreams-request-object:
@@ -13047,17 +13044,14 @@ components:
           description: Use this parameter to define a name for the restream destination.
           type: string
           example: My RTMP server
-          nullable: false
         serverUrl:
           description: Use this parameter to set the RTMP URL of the restream destination.
           type: string
           example: rtmp://my.broadcast.example.com/app
-          nullable: false
         streamKey:
           description: Use this parameter to provide the unique key of the live stream that you want to restream.
           type: string
           example: dw-dew8-q6w9-k67w-1ws8
-          nullable: false
     restreams-response-object:
       title: Restreams response object
       type: object


### PR DESCRIPTION
PR is based on [this task](https://app.asana.com/0/1204370684353095/1204986011935673/f).

Based on the [OpenAPI spec](https://swagger.io/docs/specification/data-models/data-types/#null:~:text=considered%20boolean%20values.-,Null,-OpenAPI%203.0%20does), `nullable` is a boolean property, but looks like only `nullable: true` is actually implemented and handled. ReadMe parses `nullable: true`, but does not require `nullable: false`, as that is considered the default state for every field.

If I add `nullable: false` to a field, it'll actually be rendered as `nullable: true`, which is incorrect and misleading for our users. 