### PR TITLE
Remove restream from requests, responses, snippets

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4051,13 +4051,6 @@ paths:
                         createdAt: '2020-01-31T10:17:47.000Z'
                         updatedAt: '2020-03-09T13:19:43.000Z'
                         streamKey: 30087931-229e-42cf-b5f9-e91bcc1f7332
-                        restreams:
-                        - name: YouTube
-                          serverUrl: rtmp://youtube.broadcast.example.com
-                          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385188
-                        - name: Twitch
-                          serverUrl: rtmp://twitch.broadcast.example.com
-                          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385188
                         name: Live Stream From the browser
                         public: true
                         record: true
@@ -4071,13 +4064,6 @@ paths:
                         createdAt: '2020-07-29T10:45:35.000Z'
                         updatedAt: '2020-07-29T10:45:35.000Z'
                         streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
-                        restreams:
-                        - name: YouTube
-                          serverUrl: rtmp://youtube.broadcast.example.com
-                          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
-                        - name: Twitch
-                          serverUrl: rtmp://twitch.broadcast.example.com
-                          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
                         name: Live From New York
                         public: true
                         record: true
@@ -4343,47 +4329,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bad-request'
-              examples:
-                Empty field in restreams array:
-                  description: This error occurs when a field is empty in the `restreams` array in your request.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This value should not be blank.
-                    name: restreams[0][name]
-                Missing app name in serverUrl:
-                  description: This error occurs when the rtmp app name is missing from `serverURL` in the `restreams` array.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: 'Missing app name: rtmp://[host]/[app name].'
-                    name: restreams[0][serverUrl]
-                Incorrect URL in serverUrl:
-                  description: This error occurs when the URL you set in `serverURL` is not `rtmp`.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: 'RTMP URL should have the following format: rtmp://[host]/[app name].'
-                    name: restreams[0][serverUrl]
-                Too many restream destinations:
-                  description: This error occurs when you set more than 5 restream destinations.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This collection should contain 5 elements or less.
-                    name: restreams
-                null field in the restreams array:
-                  description: This error occurs when a field is sent as `null` in the `restreams` array in your request.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This value should not be null.
-                    name: restreams[0][name]
       security:
         - apiKey: []
       x-client-action: create
@@ -4403,7 +4348,6 @@ paths:
               liveStreamCreationPayload.SetRecord(false) // Whether you are recording or not. True for record, false for not record.
               liveStreamCreationPayload.SetPublic(true) // Whether your video can be viewed by everyone, or requires authentication to see it.
               liveStreamCreationPayload.SetPlayerId("pl4f4ferf5erfr5zed4fsdd") // The unique identifier for the player.
-              liveStreamCreatePayload.SetRestreams([]RestreamsRequestObject{{Name: "My RTMP server", ServerUrl: "rtmp://my.broadcast.example.com/app", StreamKey: "dw-dew8-q6w9-k67w-1ws8"}}) // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
 
               res, err := client.LiveStreams.Create(liveStreamCreationPayload)
 
@@ -4423,14 +4367,7 @@ paths:
                   record: false, // Whether you are recording or not. True for record, false for not record.
                   name: "My Live Stream", // Add a name for your live stream here.
                   _public: true, // Whether your video can be viewed by everyone, or requires authentication to see it. 
-                  playerId: "pl4f4ferf5erfr5zed4fsdd", // The unique identifier for the player.
-                  restreams: [ // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
-                    {
-                      streamKey: "dw-dew8-q6w9-k67w-1ws8",
-                      serverUrl: "rtmp://my.broadcast.example.com/app",
-                      name: "My RTMP server",
-                    },
-                  ],
+                  playerId: "pl4f4ferf5erfr5zed4fsdd" // The unique identifier for the player.
               }; 
 
               const liveStream = await client.liveStreams.create(liveStreamCreationPayload);
@@ -4448,14 +4385,7 @@ paths:
                       record=False,
                       name="My Live Stream Video",
                       public=True,
-                      player_id="pl4f4ferf5erfr5zed4fsdd",
-                      restreams=[
-                          RestreamsRequestObject(
-                              name="My RTMP server",
-                              server_url="rtmp://my.broadcast.example.com/app",
-                              stream_key="dw-dew8-q6w9-k67w-1ws8",
-                          ),
-                      ],
+                      player_id="pl4f4ferf5erfr5zed4fsdd"
                   ) # LiveStreamCreationPayload | 
 
                   try:
@@ -4477,10 +4407,6 @@ paths:
               liveStreamCreationPayload.setName("My Live Stream Video"); // Add a name for your live stream here.
               liveStreamCreationPayload.setPublic(); // Whether your video can be viewed by everyone, or requires authentication to see it.
               liveStreamCreationPayload.setPlayerId("pl4f4ferf5erfr5zed4fsdd"); // The unique identifier for the player.
-              liveStreamCreationPayload.setRestreams(Collections.singletonList(new RestreamsRequestObject() // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
-                    .name("My RTMP server")
-                    .serverUrl("rtmp://my.broadcast.example.com/app")
-                    .streamKey("dw-dew8-q6w9-k67w-1ws8")));
 
 
               try {
@@ -4502,10 +4428,7 @@ paths:
                   record = false,
                   name = "My Live Stream Video",
                   _public = true,
-                  playerid = "pl4f4ferf5erfr5zed4fsdd",
-                  restreams = new List<RestreamsRequestObject>(){
-                      new RestreamsRequestObject(){name="My RTMP server", streamKey="dw-dew8-q6w9-k67w-1ws8", serverUrl="rtmp://my.broadcast.example.com/app" }
-                  }
+                  playerid = "pl4f4ferf5erfr5zed4fsdd"
               };
 
               try
@@ -4535,8 +4458,6 @@ paths:
                   ->setName("My Live Stream Video") // Add a name for your live stream here.
                   ->setPublic(true) // Whether your video can be viewed by everyone, or requires authentication to see it. 
                   ->setPlayerId("pl4f4ferf5erfr5zed4fsdd")); // The unique identifier for the player.
-                  ->setRestreams(array(  // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
-                      new RestreamsRequestObject(['name' => 'My RTMP server', 'serverUrl' => 'rtmp://my.broadcast.example.com/app', 'streamKey' => 'dw-dew8-q6w9-k67w-1ws8'])));
           - language: swift
             code: |
               // First install the api client: https://github.com/apivideo/api.video-ios-client#getting-started
@@ -4548,12 +4469,7 @@ paths:
                   name: "My Live Stream Video",
                   record: false,
                   _public: true,
-                  playerId: "pl4f4ferf5erfr5zed4fsdd",
-                  restreams: [RestreamsRequestObject(
-                      name: "My RTMP server",
-                      serverUrl: "rtmp://my.broadcast.example.com/app",
-                      streamKey: "dw-dew8-q6w9-k67w-1ws8"
-                  )]
+                  playerId: "pl4f4ferf5erfr5zed4fsdd"
               )
 
               LiveStreamsAPI.create(liveStreamCreationPayload: liveStreamCreationPayload) { liveStream, error in
@@ -4993,47 +4909,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bad-request'
-              examples:
-                Empty field in restreams array:
-                  description: This error occurs when a field is empty in the `restreams` array in your request.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This value should not be blank.
-                    name: restreams[0][name]
-                Missing app name in serverUrl:
-                  description: This error occurs when the rtmp app name is missing from `serverURL` in the `restreams` array.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: 'Missing app name: rtmp://[host]/[app name].'
-                    name: restreams[0][serverUrl]
-                Incorrect URL in serverUrl:
-                  description: This error occurs when the URL you set in `serverURL` is not `rtmp`.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: 'RTMP URL should have the following format: rtmp://[host]/[app name].'
-                    name: restreams[0][serverUrl]
-                Too many restream destinations:
-                  description: This error occurs when you set more than 5 restream destinations.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This collection should contain 5 elements or less.
-                    name: restreams
-                null field in the restreams array:
-                  description: This error occurs when a field is sent as `null` in the `restreams` array in your request.
-                  value:
-                    type: https://docs.api.video/reference/invalid-attribute
-                    title: An attribute is invalid.
-                    status: 400
-                    detail: This value should not be null.
-                    name: restreams[0][name]
       security:
         - apiKey: []
       x-client-action: update
@@ -5064,7 +4939,6 @@ paths:
                   liveStreamUpdatePayload.SetRecord(false) // Use this to indicate whether you want the recording on or off. On is true, off is false.
                   liveStreamUpdatePayload.SetPublic(true) // Whether your video can be viewed by everyone, or requires authentication to see it.
                   liveStreamUpdatePayload.SetPlayerId("pl4f4ferf5erfr5zed4fsdd") // The unique ID for the player associated with a live stream that you want to update.
-                  liveStreamUpdatePayload.SetRestreams([]RestreamsRequestObject{{Name: "My RTMP server", ServerUrl: "rtmp://my.broadcast.example.com/app", StreamKey: "dw-dew8-q6w9-k67w-1ws8"}}) // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations. This operation updates all restream destinations in the same request. If you do not want to modify an existing restream destination, you need to include it in your request, otherwise it is removed.
 
                   res, err := client.LiveStreams.Update(liveStreamId, liveStreamUpdatePayload)
 
@@ -5088,14 +4962,7 @@ paths:
                 name: "My Live Stream Video", // The name you want to use for your live stream.
                 _public: true, // Whether your video can be viewed by everyone, or requires authentication to see it. 
                 record: true, // Use this to indicate whether you want the recording on or off. On is true, off is false.
-                playerId: "pl45KFKdlddgk654dspkze", // The unique ID for the player associated with a live stream that you want to update.
-                restreams: [ // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
-                  {
-                    streamKey: "dw-dew8-q6w9-k67w-1ws8",
-                    serverUrl: "rtmp://my.broadcast.example.com/app",
-                    name: "My RTMP server",
-                  },
-                ],
+                playerId: "pl45KFKdlddgk654dspkze" // The unique ID for the player associated with a live stream that you want to update.
               };
 
               const liveStream = await client.liveStreams.update(liveStreamId, liveStreamUpdatePayload); 
@@ -5120,14 +4987,7 @@ paths:
                       name="My Live Stream Video",
                       public=True,
                       record=True,
-                      player_id="pl45KFKdlddgk654dspkze",
-                      restreams=[
-                          RestreamsRequestObject(
-                              name="My RTMP server",
-                              server_url="rtmp://my.broadcast.example.com",
-                              stream_key="dw-dew8-q6w9-k67w-1ws8",
-                          ),
-                      ],
+                      player_id="pl45KFKdlddgk654dspkze"
                   ) # LiveStreamUpdatePayload | 
 
                   # example passing only required values which don't have defaults set
@@ -5163,10 +5023,6 @@ paths:
                   liveStreamUpdatePayload.setPublic(); // Whether your video can be viewed by everyone, or requires authentication to see it. A setting of false will require a unique token for each view.
                   liveStreamUpdatePayload.setRecord(true); // Use this to indicate whether you want the recording on or off. On is true, off is false.
                   liveStreamUpdatePayload.setPlayerId("pl45KFKdlddgk654dspkze"); // The unique ID for the player associated with a live stream that you want to update.
-                  liveStreamUpdatePayload.setRestreams(Collections.singletonList(new RestreamsRequestObject() // Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations. This operation updates all restream destinations in the same request. If you do not want to modify an existing restream destination, you need to include it in your request, otherwise it is removed.
-                        .name("My RTMP server")
-                        .serverUrl("rtmp://my.broadcast.example.com/app")
-                        .streamKey("dw-dew8-q6w9-k67w-1ws8")));
 
 
                   try {
@@ -5238,9 +5094,7 @@ paths:
                   ->setName("My Live Stream Video") // The name you want to use for your live stream.)
                   ->setPublic(true) // Whether your video can be viewed by everyone, or requires authentication to see it. )
                   ->setRecord(true) // Use this to indicate whether you want the recording on or off. On is true, off is false.)
-                  ->setPlayerId("pl45KFKdlddgk654dspkze") // The unique ID for the player associated with a live stream that you want to update.)
-                  ->setRestreams(array(
-                    new RestreamsRequestObject(['name' => 'My RTMP server', 'serverUrl' => 'rtmp://my.broadcast.example.com/app', 'streamKey' => 'dw-dew8-q6w9-k67w-1ws8'])));
+                  ->setPlayerId("pl45KFKdlddgk654dspkze") // The unique ID for the player associated with a live stream that you want to update.);
 
 
               $liveStream = $client->liveStreams()->update($liveStreamId, $liveStreamUpdatePayload); 
@@ -5256,12 +5110,7 @@ paths:
                   name: "My Live Stream Video",
                   record: false,
                   _public: true,
-                  playerId: "pl4f4ferf5erfr5zed4fsdd",
-                  restreams: [RestreamsRequestObject(
-                      name: "My RTMP server",
-                      serverUrl: "rtmp://my.broadcast.example.com/app",
-                      streamKey: "dw-dew8-q6w9-k67w-1ws8"
-                  )]
+                  playerId: "pl4f4ferf5erfr5zed4fsdd"
               )
 
               LiveStreamsAPI.update(liveStreamId: liveStreamId, liveStreamUpdatePayload: liveStreamUpdatePayload) { liveStream, error in
@@ -11890,13 +11739,6 @@ components:
         createdAt: '2020-07-29T10:45:35.000Z'
         updatedAt: '2020-07-29T10:45:35.000Z'
         streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
-        restreams:
-        - name: YouTube
-          serverUrl: rtmp://youtube.broadcast.example.com
-          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
-        - name: Twitch
-          serverUrl: rtmp://twitch.broadcast.example.com
-          streamKey: cc1b4df0-d1c5-4064-a8f9-9f0368385135
         name: Live From New York
         public: true
         record: true
@@ -12487,11 +12329,6 @@ components:
           type: boolean
           description: 'Whether or not you are broadcasting the live video you recorded for others to see. True means you are broadcasting to viewers, false means you are not.'
           example: true
-        restreams:
-          description: Returns the list of RTMP restream destinations.
-          type: array
-          items:
-            $ref: '#/components/schemas/restreams-response-object'
         createdAt:
           type: string
           description: 'When the player was created, presented in ISO-8601 format.'
@@ -12504,7 +12341,6 @@ components:
           example: '2020-01-31T10:18:47+00:00'
       required:
         - liveStreamId
-        - restreams
     live-stream-session:
       title: LiveStreamSession
       type: object
@@ -12989,23 +12825,10 @@ components:
           type: string
           description: The unique identifier for the player.
           example: pl4f4ferf5erfr5zed4fsdd
-        restreams:
-          description: Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations.
-          maxItems: 5
-          type: array
-          items:
-            $ref: '#/components/schemas/restreams-request-object'
       example:
         name: Test live
         record: true
         playerId: pl4f4ferf5erfr5zed4fsdd
-        restreams:
-           - name: YouTube
-             serverUrl: rtmp://youtube.broadcast.example.com
-             streamKey: dw-dew8-q6w9-k67w-1ws8
-           - name: Twitch
-             serverUrl: rtmp://twitch.broadcast.example.com
-             streamKey: dw-dew8-q6w9-k67w-1ws8
     live-stream-update-payload:
       title: LiveStreamUpdatePayload
       type: object
@@ -13025,12 +12848,6 @@ components:
           type: string
           description: The unique ID for the player associated with a live stream that you want to update.
           example: pl45KFKdlddgk654dspkze
-        restreams:
-          description: Use this parameter to add, edit, or remove RTMP services where you want to restream a live stream. The list can only contain up to 5 destinations. This operation updates all restream destinations in the same request. If you do not want to modify an existing restream destination, you need to include it in your request, otherwise it is removed.
-          maxItems: 5
-          type: array
-          items:
-            $ref: '#/components/schemas/restreams-request-object'
     restreams-request-object:
       title: Restreams request object
       description: Adding restream destinations is optional. However, if you set a restream destination, you must provide all attributes for each destination.


### PR DESCRIPTION
The changes are for [this Asana task](https://app.asana.com/0/1204307844224163/1204997218040593).

**Context**:

> FYI we are going to hide the changelog, docs, and dashboard parts for a few more days. This is because the feature, while in prod in the API, is still unstable. We want to keep monitoring live creation for a few more days, and check that there are no more problems with that, until we make official that we support restreams.

**Please review the following**:

- code snippets have no leftover elements from restreams (and no formatting issues)
- request & response schemas for `POST` and `PATCH` live streams are OK

Also please confirm that it is **OK to leave these unused schema references** in the OAS:

- `restreams-request-object`
- `restreams-response-object`