### PR TITLE
Add possible values to dimension params

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -9348,9 +9348,9 @@ paths:
           - `videoId`: Returns analytics based on the public video identifiers.
           - `emittedAt`: Returns analytics based on the times of the play events. The API returns data in specific interval groups. When the date period you set in `from` and `to` is less than or equals to 2 days, the response for this dimension is grouped in hourly intervals. Otherwise, it is grouped in daily intervals.
           - `country`: Returns analytics based on the viewers' country. The list of supported country names are based on the [GeoNames public database](https://www.geonames.org/countries/).
-          - `deviceType`: Returns analytics based on the type of device used by the viewers during the play event.
-          - `operatingSystem`: Returns analytics based on the operating system used by the viewers during the play event.
-          - `browser`: Returns analytics based on the browser used by the viewers during the play event.
+          - `deviceType`: Returns analytics based on the type of device used by the viewers during the play event. Possible response values are: `computer`, `phone`, `tablet`, `tv`, `console`, `wearable`, `unknown`.
+          - `operatingSystem`: Returns analytics based on the operating system used by the viewers during the play event. Response values include `windows`, `mac osx`, `android`, `ios`, `linux`.
+          - `browser`: Returns analytics based on the browser used by the viewers during the play event. Response values include `chrome`, `firefox`, `edge`, `opera`.
         required: true
         style: form
         explode: false
@@ -10104,9 +10104,9 @@ paths:
           - `liveStreamId`: Returns analytics based on the public live stream identifiers.
           - `emittedAt`: Returns analytics based on the times of the play events. The API returns data in specific interval groups. When the date period you set in `from` and `to` is less than or equals to 2 days, the response for this dimension is grouped in hourly intervals. Otherwise, it is grouped in daily intervals.
           - `country`: Returns analytics based on the viewers' country. The list of supported country names are based on the [GeoNames public database](https://www.geonames.org/countries/).
-          - `deviceType`: Returns analytics based on the type of device used by the viewers during the play event.
-          - `operatingSystem`: Returns analytics based on the operating system used by the viewers during the play event.
-          - `browser`: Returns analytics based on the browser used by the viewers during the play event.
+          - `deviceType`: Returns analytics based on the type of device used by the viewers during the play event. Possible response values are: `computer`, `phone`, `tablet`, `tv`, `console`, `wearable`, `unknown`.
+          - `operatingSystem`: Returns analytics based on the operating system used by the viewers during the play event. Response values include `windows`, `mac osx`, `android`, `ios`, `linux`.
+          - `browser`: Returns analytics based on the browser used by the viewers during the play event. Response values include `chrome`, `firefox`, `edge`, `opera`.
         required: true
         style: form
         explode: false


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204370684353095/1205105335278237/f).

We did not have a list of the values returned for most of the dimensions in the Analytics endpoint, so I added them. For `operatingSystem` and `browser`, the list is not exhaustive. Source: [Slack](https://api-video.slack.com/archives/C0593HQ4HDJ/p1685629895633549?thread_ts=1685619731.422309&cid=C0593HQ4HDJ)